### PR TITLE
Fixed issue where RCON connections will panic

### DIFF
--- a/connector/connections/rcon.go
+++ b/connector/connections/rcon.go
@@ -38,7 +38,7 @@ func NewRCON(name string, opts *ConnectionOptions) IConnection {
 	return &RCON{
 		opts:    opts,
 		cache:   cache.New(opts.CacheExpiration, opts.CacheCleanupInterval),
-		created: time.Now(),
+		created: time.Time{},
 	}
 }
 


### PR DESCRIPTION
Currently RCON connections will panic because the `RCON.rcon` field is nil upon call to `NewRCON`, despite `created` being set to the current time. Because `created` is set to the current time, `runRCONCommand` will not call `RCON.Reconnect` to establish a connection to the server, resulting a panic due to accessing a nil pointer. This PR sets the initial `created` time to Unix Epoch time, ensuring that the connection to the RCON server is established.